### PR TITLE
Added Fr En Neural Translation model

### DIFF
--- a/translator-fr-en/Dockerfile
+++ b/translator-fr-en/Dockerfile
@@ -1,0 +1,1 @@
+FROM chritter/translator-fr-en:0.5

--- a/translator-fr-en/README.md
+++ b/translator-fr-en/README.md
@@ -1,0 +1,1 @@
+# AI French-to-English Translator model

--- a/translator-fr-en/README.md
+++ b/translator-fr-en/README.md
@@ -1,1 +1,5 @@
 # AI French-to-English Translator model
+
+AI language translation model which translates from French to English.
+
+Docker image `chritter/translator-fr-en:0.5` was built using the instructions in [here](https://gitlab.com/dsd4/seldon_api_deploy/argo_seldon_deployments/-/tree/master/10_translator_mlflow).


### PR DESCRIPTION
Hello,
I would like to add the French-to-English AI machine translation model to Artifactory. The model contains an mlflow artifact packaged to work for deployment with Seldon.

See details in README.

Thanks!