### PR TITLE
Add default mpi-operator image

### DIFF
--- a/databricks-python/Dockerfile
+++ b/databricks-python/Dockerfile
@@ -1,9 +1,0 @@
-# Image for executing python workloads, provided by databricks
-#
-# https://github.com/databricks/containers/blob/master/ubuntu/python/Dockerfile
-
-FROM databricksruntime/python
-
-RUN groupadd -g 1000 jovyan && useradd -u 1000 jovyan -g jovyan
-
-USER jovyan:jovyan

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -15,6 +15,7 @@ RUN apt update && apt install -y --no-install-recommends \
             sqlite3 \
             curl \
             ca-certificates \
+        &&  apt-get upgrade -y \
 		&& rm -rf /var/lib/apt/lists/*
 
 # Add priviledge separation directoy to run sshd as root.

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -14,6 +14,7 @@ RUN apt update && apt install -y --no-install-recommends \
             openmpi-bin \
             sqlite3 \
             curl \
+            ca-certificates \
 		&& rm -rf /var/lib/apt/lists/*
 
 # Add priviledge separation directoy to run sshd as root.

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update \
             sqlite3 \
             curl \
             ca-certificates \
-            minizip \
+        && apt remove zlib1g \
 		&& rm -rf /var/lib/apt/lists/*
 
 # Add priviledge separation directoy to run sshd as root.

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -1,0 +1,65 @@
+# Base mpi-operator dockerfile from https://github.com/kubeflow/mpi-operator/blob/master/build/base/Dockerfile
+# Added open-mpi https://github.com/kubeflow/mpi-operator/blob/master/build/base/openmpi.Dockerfile
+# Added configuration for OpenM++ from https://github.com/openmpp/docker/blob/master/ompp-run-debian/Dockerfile
+# Added kubectl cli for interacting with kubeapi server from containers
+
+FROM debian:bullseye
+
+ARG port=2222
+
+RUN apt update && apt install -y --no-install-recommends \
+			openssh-server \
+			openssh-client \
+            libcap2-bin \
+            openmpi-bin \
+            sqlite3 \
+		&& rm -rf /var/lib/apt/lists/*
+
+# Add priviledge separation directoy to run sshd as root.
+RUN mkdir -p /var/run/sshd
+
+# Add capability to run sshd as non-root.
+RUN setcap CAP_NET_BIND_SERVICE=+eip /usr/sbin/sshd
+RUN apt remove libcap2-bin -y
+
+# Allow OpenSSH to talk to containers without asking for confirmation
+# by disabling StrictHostKeyChecking.
+# mpi-operator mounts the .ssh folder from a Secret. For that to work, we need
+# to disable UserKnownHostsFile to avoid write permissions.
+# Disabling StrictModes avoids directory and files read permission checks.
+RUN sed -i "s/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g" /etc/ssh/ssh_config \
+    && echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config \
+    && sed -i "s/[ #]\(.*Port \).*/ \1$port/g" /etc/ssh/ssh_config \
+    && sed -i "s/#\(StrictModes \).*/\1no/g" /etc/ssh/sshd_config \
+    && sed -i "s/#\(Port \).*/\1$port/g" /etc/ssh/sshd_config
+
+# Install kubectl cli to be able to utilize file transfer functionality between containers
+ARG KUBECTL_VERSION=v1.28.2
+ARG KUBECTL_URL=https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+ARG KUBECTL_SHA=c922440b043e5de1afa3c1382f8c663a25f055978cbc6e8423493ec157579ec5
+
+RUN curl -LO "${KUBECTL_URL}" \
+    && echo "${KUBECTL_SHA} kubectl" | sha256sum -c - \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
+# Set local openM++ timezone, default ulimit
+RUN rm -f /etc/localtime && \
+ln -s /usr/share/zoneinfo/America/Toronto /etc/localtime && \
+echo "ulimit -S -s 65536" >> etc/bash.bashrc
+
+# Add non-root user
+RUN useradd -m mpiuser
+WORKDIR /home/mpiuser
+
+# Configurations for running sshd as non-root.
+COPY --chown=mpiuser sshd_config .sshd_config
+RUN echo "Port $port" >> /home/mpiuser/.sshd_config
+
+# Stepdown to non-root user
+USER mpiuser
+
+SHELL ["/bin/bash"]
+
+# default command check MPIEXEC verson, when used as a kubernetes container override with custom mpiexec execution
+CMD mpiexec -V && ulimit -S -s

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && apt install -y --no-install-recommends \
             libcap2-bin \
             openmpi-bin \
             sqlite3 \
+            curl \
 		&& rm -rf /var/lib/apt/lists/*
 
 # Add priviledge separation directoy to run sshd as root.

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -7,7 +7,9 @@ FROM debian:bookworm
 
 ARG port=2222
 
-RUN apt update && apt install -y --no-install-recommends \
+RUN apt update \
+        && apt-get upgrade -y \
+        && apt install -y --no-install-recommends \
 			openssh-server \
 			openssh-client \
             libcap2-bin \
@@ -15,7 +17,7 @@ RUN apt update && apt install -y --no-install-recommends \
             sqlite3 \
             curl \
             ca-certificates \
-        &&  apt-get upgrade -y \
+            minizip \
 		&& rm -rf /var/lib/apt/lists/*
 
 # Add priviledge separation directoy to run sshd as root.

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -7,9 +7,7 @@ FROM debian:bookworm
 
 ARG port=2222
 
-RUN apt update \
-        && apt-get upgrade -y \
-        && apt install -y --no-install-recommends \
+RUN apt update && apt install -y --no-install-recommends \
 			openssh-server \
 			openssh-client \
             libcap2-bin \
@@ -17,7 +15,6 @@ RUN apt update \
             sqlite3 \
             curl \
             ca-certificates \
-        && apt remove zlib1g \
 		&& rm -rf /var/lib/apt/lists/*
 
 # Add priviledge separation directoy to run sshd as root.

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -3,7 +3,7 @@
 # Added configuration for OpenM++ from https://github.com/openmpp/docker/blob/master/ompp-run-debian/Dockerfile
 # Added kubectl cli for interacting with kubeapi server from containers
 
-FROM debian:bullseye
+FROM debian:bookworm
 
 ARG port=2222
 

--- a/mpi-operator/sshd_config
+++ b/mpi-operator/sshd_config
@@ -1,0 +1,3 @@
+PidFile /home/mpiuser/sshd.pid
+HostKey /home/mpiuser/.ssh/id_rsa
+StrictModes no


### PR DESCRIPTION
[fix: remove failing databricks-python image](https://github.com/StatCan/aaw-contrib-containers/commit/6ed10b2a6b7045c69700c446292a3782179aad68)

This is not being used, it can be added again if needed. Failing build due to CVE in latest base image.

[feat: add new mpi-operator based image](https://github.com/StatCan/aaw-contrib-containers/commit/bc76f81fa81d1824fe4e4aeeb9a44a9cba79a63e)

Added an mpi-operator based image instead of an openm++ based image.

* Base mpi-operator dockerfile from https://github.com/kubeflow/mpi-operator/blob/master/build/base/Dockerfile
* Added open-mpi https://github.com/kubeflow/mpi-operator/blob/master/build/base/openmpi.Dockerfile
* Added configuration for OpenM++ from https://github.com/openmpp/docker/blob/master/ompp-run-debian/Dockerfile
* Added kubectl cli for interacting with kubeapi server from containers

Cannot easily get rid of CVE reported in debian the zlib1g package https://avd.aquasec.com/nvd/2023/cve-2023-45853/ is reported as fixed https://lists.debian.org/debian-lts-announce/2023/11/msg00026.html and should be ignored https://github.com/aquasecurity/trivy/discussions/6722