### PR TITLE
Add openmpp and build deps to ompp image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,8 +74,10 @@ jobs:
         sudo chmod +x hadolint
         ./hadolint ${{ matrix.image }}/Dockerfile --no-fail
     
-    # Container build and push to a Azure Container registry (ACR)
+    # Container build and push to a Azure Container registry (ACR), push a tag with the branch name as well
     - run: |
         docker pull localhost:5000/${{ matrix.image }}:${{ github.sha }}
         docker tag localhost:5000/${{ matrix.image }}:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.sha }}
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.sha }}
+        docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.base_ref }}
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.base_ref }}

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -56,7 +56,7 @@ WORKDIR /home/mpiuser
 
 # Configurations for running sshd as non-root.
 COPY --chown=mpiuser sshd_config .sshd_config
-RUN echo -e "\nPort $port" >> /home/mpiuser/.sshd_config
+RUN /bin/echo -e "\nPort $port" >> /home/mpiuser/.sshd_config
 
 # Stepdown to non-root user
 USER mpiuser

--- a/ompp-run-ubuntu/Dockerfile
+++ b/ompp-run-ubuntu/Dockerfile
@@ -34,6 +34,10 @@ FROM ubuntu:22.04
 
 # disable debconf terminal input
 ARG DEBIAN_FRONTEND=noninteractive
+ARG OMPP_USER=ompp
+ARG OMPP_GROUP=ompp
+ARG OMPP_UID=1999
+ARG OMPP_GID=1999
 
 # For OncoSim MPI inject to the default bashrc as non other exist, can change later
 RUN echo "ulimit -S -s 65536" >> etc/bash.bashrc && \
@@ -49,10 +53,19 @@ RUN echo "ulimit -S -s 65536" >> etc/bash.bashrc && \
     tree \
     zip \
     sqlite3 \
-    openmpi-bin \
+    g++ \
+    make \
     unixodbc && \
     apt-get upgrade -y && \
     rm -rf /var/lib/apt/lists/*
+
+# download and install Go
+RUN GO_VER=1.22.5; \
+  curl -L -o /tmp/go_setup.tar.gz https://dl.google.com/go/go${GO_VER}.linux-amd64.tar.gz && \
+  tar -xzf /tmp/go_setup.tar.gz -C /tmp && \
+  mv /tmp/go / && \
+  rm -rf /tmp/gocache /tmp/tmp && \
+  rm /tmp/go_setup.tar.gz
 
 # Install kubectl cli to be able to utilize file transfer functionality between containers
 ARG KUBECTL_VERSION=v1.28.2
@@ -64,27 +77,22 @@ RUN curl -LO "${KUBECTL_URL}" \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl
 
+# Install OpenM++
+ARG OMPP_VERSION=v1.17.4
+ARG OMPP_URL=https://github.com/openmpp/main/releases/download/${OMPP_VERSION}/openmpp_debian-11_20240731.tar.gz
+ARG OMPP_SHA=4ecb8c6b31030cf4ec92030b3e2ada2d5a57b557829d2b98e69d6326931ccac6
+
+RUN curl -LO "${OMPP_URL}" \
+    && echo "${OMPP_SHA} openmpp_debian-11_20240731.tar.gz" | sha256sum -c - \
+    && tar -xf openmpp_debian-11_20240731.tar.gz -C /home/${OMPP_USER}
+
 # set local openM++ timezone
 RUN rm -f /etc/localtime && \
-    ln -s /usr/share/zoneinfo/America/Toronto /etc/localtime && \
-    mkdir -p /var/run/sshd && \
-# Allow OpenSSH to talk to containers without asking for confirmation
-# by disabling StrictHostKeyChecking.
-# mpi-operator mounts the .ssh folder from a Secret. For that to work, we need
-# to disable UserKnownHostsFile to avoid write permissions.
-# Disabling StrictModes avoids directory and files read permission checks.
-    sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
-    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
-    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config
+    ln -s /usr/share/zoneinfo/America/Toronto /etc/localtime
 
 # Done with installation
 # set user, work directory and entry point
 #
-ARG OMPP_USER=ompp
-ARG OMPP_GROUP=ompp
-ARG OMPP_UID=1999
-ARG OMPP_GID=1999
-
 ENV OMPP_USER=${OMPP_USER} \
     OMPP_GROUP=${OMPP_GROUP} \
     OMPP_UID=${OMPP_UID} \
@@ -92,9 +100,8 @@ ENV OMPP_USER=${OMPP_USER} \
     HOME=/home/${OMPP_USER}
 
 RUN groupadd -g ${OMPP_GID} ${OMPP_GROUP} && \
-    useradd --no-log-init -g ${OMPP_GROUP} -u ${OMPP_UID} ${OMPP_USER}
-
-RUN mkdir cd ${HOME} && \
+    useradd --no-log-init -g ${OMPP_GROUP} -u ${OMPP_UID} ${OMPP_USER} && \
+    mkdir cd ${HOME} && \
     chown ${OMPP_UID}:${OMPP_GID} ${HOME}
 
 USER $OMPP_USER

--- a/ompp-run-ubuntu/Dockerfile
+++ b/ompp-run-ubuntu/Dockerfile
@@ -77,22 +77,11 @@ RUN curl -LO "${KUBECTL_URL}" \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl
 
-# Install OpenM++
-ARG OMPP_VERSION=v1.17.4
-ARG OMPP_URL=https://github.com/openmpp/main/releases/download/${OMPP_VERSION}/openmpp_debian-11_20240731.tar.gz
-ARG OMPP_SHA=4ecb8c6b31030cf4ec92030b3e2ada2d5a57b557829d2b98e69d6326931ccac6
-
-RUN curl -LO "${OMPP_URL}" \
-    && echo "${OMPP_SHA} openmpp_debian-11_20240731.tar.gz" | sha256sum -c - \
-    && tar -xf openmpp_debian-11_20240731.tar.gz -C /home/${OMPP_USER}
-
 # set local openM++ timezone
 RUN rm -f /etc/localtime && \
     ln -s /usr/share/zoneinfo/America/Toronto /etc/localtime
 
-# Done with installation
-# set user, work directory and entry point
-#
+# set user, create home/work directories
 ENV OMPP_USER=${OMPP_USER} \
     OMPP_GROUP=${OMPP_GROUP} \
     OMPP_UID=${OMPP_UID} \
@@ -102,7 +91,17 @@ ENV OMPP_USER=${OMPP_USER} \
 RUN groupadd -g ${OMPP_GID} ${OMPP_GROUP} && \
     useradd --no-log-init -g ${OMPP_GROUP} -u ${OMPP_UID} ${OMPP_USER} && \
     mkdir cd ${HOME} && \
-    chown ${OMPP_UID}:${OMPP_GID} ${HOME}
+    mkdir cd ${HOME}/work && \
+    chown -R ${OMPP_UID}:${OMPP_GID} ${HOME} 
+
+# Install OpenM++ into user home directory
+ARG OMPP_VERSION=v1.17.4
+ARG OMPP_URL=https://github.com/openmpp/main/releases/download/${OMPP_VERSION}/openmpp_debian-11_20240731.tar.gz
+ARG OMPP_SHA=4ecb8c6b31030cf4ec92030b3e2ada2d5a57b557829d2b98e69d6326931ccac6
+
+RUN curl -LO "${OMPP_URL}" \
+    && echo "${OMPP_SHA} openmpp_debian-11_20240731.tar.gz" | sha256sum -c - \
+    && tar -xf ./openmpp_debian-11_20240731.tar.gz -C ${HOME}
 
 USER $OMPP_USER
 

--- a/ompp-run-ubuntu/Dockerfile
+++ b/ompp-run-ubuntu/Dockerfile
@@ -89,10 +89,8 @@ ENV OMPP_USER=${OMPP_USER} \
     HOME=/home/${OMPP_USER}
 
 RUN groupadd -g ${OMPP_GID} ${OMPP_GROUP} && \
-    useradd --no-log-init -g ${OMPP_GROUP} -u ${OMPP_UID} ${OMPP_USER} && \
-    mkdir cd ${HOME} && \
-    mkdir cd ${HOME}/work && \
-    chown -R ${OMPP_UID}:${OMPP_GID} ${HOME} 
+    useradd --no-log-init -m -g ${OMPP_GROUP} -u ${OMPP_UID} ${OMPP_USER} && \
+    mkdir ${HOME}/work
 
 # Install OpenM++ into user home directory
 ARG OMPP_VERSION=v1.17.4


### PR DESCRIPTION
Main feature is to add a version of OpenM++ so that users can build their models from the docker image, as well as run some of the OpenM++ bundled utilities (such as the new dbget), if desired.

1. Add latest version of OpenM++ to ompp image
2. Add build dependencies (make, g++) to ompp image
3. Add golang to ompp image (for OpenM++ utilities)
4. Fix error in mpi image (built in echo does not respect flags)
5. Refactoring / cleanup
6. Update workflow to push the branch name as well, so that the OpenM++ version can be easily referenced
