### PR TITLE
new openmpp version, config modified, trivy updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
     env: 
       TRIVY_VERSION: "v0.43.1"
       HADOLINT_VERSION: "2.12.0"
+      TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db"
+      TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db"
     needs: listimages
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
       HADOLINT_VERSION: "2.12.0"
       TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db"
       TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db"
+      TRIVY_DISABLE_VEX_NOTICE: true
     needs: listimages
     strategy:
       fail-fast: false
@@ -53,7 +54,7 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image localhost:5000/${{ matrix.image }}:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+        trivy image localhost:5000/${{ matrix.image }}:${{ github.sha }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
 
     # Run Hadolint
     - name: Run Hadolint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       run: echo "::set-output name=matrix::{\"image\":[$(ls -d */ | sed 's~\(.*\)/$~\"\1\"~g' | paste -sd ',')]}"
   build:
     env: 
-      TRIVY_VERSION: "v0.43.1"
+      TRIVY_VERSION: "v0.57.0"
       HADOLINT_VERSION: "2.12.0"
       TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db"
       TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
     env: 
       TRIVY_VERSION: "v0.43.1"
       HADOLINT_VERSION: "2.12.0"
+      OPENMPP_VERSION: "1.17.5"
     needs: listimages
     strategy:
       fail-fast: false
@@ -79,5 +80,5 @@ jobs:
         docker pull localhost:5000/${{ matrix.image }}:${{ github.sha }}
         docker tag localhost:5000/${{ matrix.image }}:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.sha }}
         docker push ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.sha }}
-        docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.event.base_ref }}
-        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.event.base_ref }}
+        docker tag ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{ github.sha }} ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{  env.OPENMPP_VERSION  }}
+        docker push ${{ env.REGISTRY_NAME }}.azurecr.io/${{ matrix.image }}:${{  env.OPENMPP_VERSION  }}

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -36,9 +36,9 @@ RUN sed -i "s/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g" /etc/ssh/ssh_config \
     && sed -i "s/#\(Port \).*/\1$port/g" /etc/ssh/sshd_config
 
 # Install kubectl cli to be able to utilize file transfer functionality between containers
-ARG KUBECTL_VERSION=v1.31.2
+ARG KUBECTL_VERSION=v1.28.11
 ARG KUBECTL_URL=https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-ARG KUBECTL_SHA=399e9d1995da80b64d2ef3606c1a239018660d8b35209fba3f7b0bc11c631c68
+ARG KUBECTL_SHA=1dba63e1a5c9520fc516c6e817924d927b9b83b8e08254c8fe2a2edb65da7a9c
 
 RUN curl -LO "${KUBECTL_URL}" \
     && echo "${KUBECTL_SHA} kubectl" | sha256sum -c - \

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -51,7 +51,7 @@ ln -s /usr/share/zoneinfo/America/Toronto /etc/localtime && \
 echo "ulimit -S -s 65536" >> etc/bash.bashrc
 
 # Add non-root user
-RUN useradd -m mpiuser
+RUN useradd -s /usr/bin/bash -m mpiuser
 WORKDIR /home/mpiuser
 
 # Configurations for running sshd as non-root.

--- a/mpi-operator/Dockerfile
+++ b/mpi-operator/Dockerfile
@@ -36,9 +36,9 @@ RUN sed -i "s/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g" /etc/ssh/ssh_config \
     && sed -i "s/#\(Port \).*/\1$port/g" /etc/ssh/sshd_config
 
 # Install kubectl cli to be able to utilize file transfer functionality between containers
-ARG KUBECTL_VERSION=v1.28.2
+ARG KUBECTL_VERSION=v1.31.2
 ARG KUBECTL_URL=https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-ARG KUBECTL_SHA=c922440b043e5de1afa3c1382f8c663a25f055978cbc6e8423493ec157579ec5
+ARG KUBECTL_SHA=399e9d1995da80b64d2ef3606c1a239018660d8b35209fba3f7b0bc11c631c68
 
 RUN curl -LO "${KUBECTL_URL}" \
     && echo "${KUBECTL_SHA} kubectl" | sha256sum -c - \

--- a/ompp-run-ubuntu/Dockerfile
+++ b/ompp-run-ubuntu/Dockerfile
@@ -94,12 +94,13 @@ RUN groupadd -g ${OMPP_GID} ${OMPP_GROUP} && \
 
 # Install OpenM++ into user home directory
 ARG OMPP_VERSION=v1.17.5
-ARG OMPP_URL=https://github.com/openmpp/main/releases/download/${OMPP_VERSION}/openmpp_debian-11_20241021.tar.gz
+ARG OMPP_DATE=20241021
+ARG OMPP_URL=https://github.com/openmpp/main/releases/download/${OMPP_VERSION}/openmpp_debian-11_${OMPP_DATE}.tar.gz
 ARG OMPP_SHA=79084a009f3bad3c0d81cb12ccc844458d29b70d199352233aad3d94489427c9
 
 RUN curl -LO "${OMPP_URL}" \
-    && echo "${OMPP_SHA} openmpp_debian-11_20240731.tar.gz" | sha256sum -c - \
-    && tar -xf ./openmpp_debian-11_20240731.tar.gz -C ${HOME}
+    && echo "${OMPP_SHA} openmpp_debian-11_${OMPP_DATE}.tar.gz" | sha256sum -c - \
+    && tar -xf ./openmpp_debian-11_${OMPP_DATE}.tar.gz -C ${HOME}
 
 USER $OMPP_USER
 

--- a/ompp-run-ubuntu/Dockerfile
+++ b/ompp-run-ubuntu/Dockerfile
@@ -93,9 +93,9 @@ RUN groupadd -g ${OMPP_GID} ${OMPP_GROUP} && \
     mkdir ${HOME}/work
 
 # Install OpenM++ into user home directory
-ARG OMPP_VERSION=v1.17.4
-ARG OMPP_URL=https://github.com/openmpp/main/releases/download/${OMPP_VERSION}/openmpp_debian-11_20240731.tar.gz
-ARG OMPP_SHA=4ecb8c6b31030cf4ec92030b3e2ada2d5a57b557829d2b98e69d6326931ccac6
+ARG OMPP_VERSION=v1.17.5
+ARG OMPP_URL=https://github.com/openmpp/main/releases/download/${OMPP_VERSION}/openmpp_debian-11_20241021.tar.gz
+ARG OMPP_SHA=79084a009f3bad3c0d81cb12ccc844458d29b70d199352233aad3d94489427c9
 
 RUN curl -LO "${OMPP_URL}" \
     && echo "${OMPP_SHA} openmpp_debian-11_20240731.tar.gz" | sha256sum -c - \

--- a/ompp-run-ubuntu/Dockerfile
+++ b/ompp-run-ubuntu/Dockerfile
@@ -68,9 +68,9 @@ RUN GO_VER=1.22.5; \
   rm /tmp/go_setup.tar.gz
 
 # Install kubectl cli to be able to utilize file transfer functionality between containers
-ARG KUBECTL_VERSION=v1.31.2
+ARG KUBECTL_VERSION=v1.28.11
 ARG KUBECTL_URL=https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-ARG KUBECTL_SHA=399e9d1995da80b64d2ef3606c1a239018660d8b35209fba3f7b0bc11c631c68
+ARG KUBECTL_SHA=1dba63e1a5c9520fc516c6e817924d927b9b83b8e08254c8fe2a2edb65da7a9c
 
 RUN curl -LO "${KUBECTL_URL}" \
     && echo "${KUBECTL_SHA} kubectl" | sha256sum -c - \

--- a/ompp-run-ubuntu/Dockerfile
+++ b/ompp-run-ubuntu/Dockerfile
@@ -68,9 +68,9 @@ RUN GO_VER=1.22.5; \
   rm /tmp/go_setup.tar.gz
 
 # Install kubectl cli to be able to utilize file transfer functionality between containers
-ARG KUBECTL_VERSION=v1.28.2
+ARG KUBECTL_VERSION=v1.31.2
 ARG KUBECTL_URL=https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-ARG KUBECTL_SHA=c922440b043e5de1afa3c1382f8c663a25f055978cbc6e8423493ec157579ec5
+ARG KUBECTL_SHA=399e9d1995da80b64d2ef3606c1a239018660d8b35209fba3f7b0bc11c631c68
 
 RUN curl -LO "${KUBECTL_URL}" \
     && echo "${KUBECTL_SHA} kubectl" | sha256sum -c - \


### PR DESCRIPTION
1. Bump OpenM++ to latest version, 1.17.5
2. Use a hardcoded env variable for tagging OpenM++ version in workflow
3. Update MPI image to ensure the bash shell is used for the mpiuser over ssh connections
4. Upgrade kubectl to 1.28.11 due to detected CVE, latest we can use with the current version of the AAW clusters
5. Upgrade trivy to be able to accept multiple database urls, add mirrors due to gitbub timeouts