### PR TITLE
feat: update trivy in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,12 @@ jobs:
       run: echo "::set-output name=matrix::{\"image\":[$(ls -d */ | sed 's~\(.*\)/$~\"\1\"~g' | paste -sd ',')]}"
   build:
     env: 
-      TRIVY_VERSION: "v0.43.1"
+      TRIVY_VERSION: "v0.57.0"
       HADOLINT_VERSION: "2.12.0"
       OPENMPP_VERSION: "1.17.5"
+      TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db"
+      TRIVY_JAVA_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db"
+      TRIVY_DISABLE_VEX_NOTICE: true
     needs: listimages
     strategy:
       fail-fast: false
@@ -66,7 +69,7 @@ jobs:
       run: |
         printf ${{ secrets.CVE_ALLOWLIST }} > .trivyignore
         curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin ${{ env.TRIVY_VERSION }}
-        trivy image localhost:5000/${{ matrix.image }}:${{ github.sha }} --exit-code 1 --timeout=20m --security-checks vuln --severity CRITICAL
+        trivy image localhost:5000/${{ matrix.image }}:${{ github.sha }} --exit-code 1 --timeout=20m --scanners vuln --severity CRITICAL
 
     # Run Hadolint
     - name: Run Hadolint


### PR DESCRIPTION
Follow-up to https://github.com/StatCan/aaw-contrib-containers/pull/130

- Upgrade trivy to be able to accept multiple database urls, add mirrors due to gitbub timeouts